### PR TITLE
Split buffering from the StreamableUploader into a WriteStream class

### DIFF
--- a/src/Storage/Bucket.php
+++ b/src/Storage/Bucket.php
@@ -739,4 +739,27 @@ class Bucket
     {
         return $this->identity['bucket'];
     }
+
+    /**
+     * Returns whether the bucket with the given file prefix is writable.
+     * Tries to create a temporary file as a resumable upload which will
+     * not be completed (and cleaned up by GCS).
+     *
+     * @param  string $file Optional file to try to write.
+     * @return boolean
+     */
+    public function isWritable($file = null) {
+        $file = $file ?: '__tempfile';
+        $uploader = $this->getResumableUploader(
+          Psr7\stream_for(''),
+          ['name' => $file]
+        );
+        try {
+            $uploader->getResumeUri();
+        } catch (ServiceException $e) {
+            return false;
+        }
+
+        return true;
+    }
 }

--- a/src/Storage/ReadStream.php
+++ b/src/Storage/ReadStream.php
@@ -1,0 +1,70 @@
+<?php
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage;
+
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * A Stream implementation that wraps a GuzzleHttp download stream to
+ * provide `getSize()` from the response headers.
+ */
+class ReadStream implements StreamInterface
+{
+    use StreamDecoratorTrait;
+
+    private $stream;
+
+    /**
+     * Create a new ReadStream.
+     *
+     * @param StreamInterface $stream The stream interface to wrap
+     */
+    public function __construct($stream)
+    {
+        $this->stream = $stream;
+    }
+
+    /**
+     * Return the full size of the buffer. If the underlying stream does
+     * not report it's size, try to fetch the size from the Content-Length
+     * response header.
+     *
+     * @return int The size of the stream.
+     */
+    public function getSize()
+    {
+        return $this->stream->getSize() ?: $this->getSizeFromMetadata();
+    }
+
+    /**
+     * Attempt to fetch the size from the Content-Length response header.
+     * If we cannot, return 0.
+     *
+     * @return int The Size of the stream
+     */
+    private function getSizeFromMetadata()
+    {
+        foreach ($this->stream->getMetadata('wrapper_data') as $value) {
+            if (substr($value, 0, 15) == "Content-Length:") {
+                return (int) substr($value, 16);
+            }
+        }
+        return 0;
+    }
+}

--- a/src/Storage/StreamWrapper.php
+++ b/src/Storage/StreamWrapper.php
@@ -31,6 +31,27 @@ class StreamWrapper
 {
     const DEFAULT_PROTOCOL = 'gs';
 
+    const STAT_KEYS = [
+        'dev',
+        'ino',
+        'mode',
+        'nlink',
+        'uid',
+        'gid',
+        'rdev',
+        'size',
+        'atime',
+        'mtime',
+        'ctime',
+        'blksize',
+        'blocks'
+    ];
+
+    const FILE_WRITABLE_MODE = 33206; // 100666 in octal
+    const FILE_READABLE_MODE = 33060; // 100444 in octal
+    const DIRECTORY_WRITABLE_MODE = 16895; // 40777 in octal
+    const DIRECTORY_READABLE_MODE = 16676; // 40444 in octal
+
     // Must be public according to the PHP documentation
     public $context;
 
@@ -40,7 +61,6 @@ class StreamWrapper
     private $protocol;
     private $bucket;
     private $file;
-    private $mode;
 
     /**
      * @var StorageClient[] $clients The default clients to use if using
@@ -115,7 +135,7 @@ class StreamWrapper
      *
      * @param string $path The path of the resource to open
      * @param string $mode The fopen mode. Currently only supports ('r', 'rb', 'rt', 'w', 'wb', 'wt')
-     * @param int $flags Bitwise options STREAM_USE_PATH|STREAM_REPORT_ERRORS
+     * @param int $flags Bitwise options STREAM_USE_PATH|STREAM_REPORT_ERRORS|STREAM_MUST_SEEK
      * @param string $openedPath Will be set to the path on success if STREAM_USE_PATH option is set
      * @return bool
      */
@@ -123,7 +143,9 @@ class StreamWrapper
     {
         // @codingStandardsIgnoreEnd
         $client = $this->openPath($path);
-        $this->mode = $mode;
+
+        // strip off 'b' or 't' from the mode
+        $mode = rtrim($mode, 'bt');
 
         $options = [];
         if ($this->context) {
@@ -133,16 +155,21 @@ class StreamWrapper
             }
         }
 
-        if ($this->isWriteable()) {
-            $options['name'] = $this->file;
-            $this->stream = $this->bucket->getStreamableUploader(
-                '',
-                $options
+        if ($mode == 'w') {
+            $this->stream = new WriteStream();
+            $this->stream->setUploader(
+                $this->bucket->getStreamableUploader(
+                    $this->stream,
+                    $options + ['name' => $this->file]
+                )
             );
-        } elseif ($this->isReadable()) {
+        } elseif ($mode == 'r') {
             try {
+                // Lazy read from the source
                 $options['httpOptions']['stream'] = true;
-                $this->stream = $this->bucket->object($this->file)->downloadAsStream($options);
+                $this->stream = new ReadStream(
+                    $this->bucket->object($this->file)->downloadAsStream($options)
+                );
 
                 // Wrap the response in a caching stream to make it seekable
                 if (!$this->stream->isSeekable() && ($flags & STREAM_MUST_SEEK)) {
@@ -169,21 +196,6 @@ class StreamWrapper
         return false;
     }
 
-    private function getStream()
-    {
-        return $this->stream;
-    }
-
-    private function isWriteable()
-    {
-        return in_array($this->mode, ['w', 'wb', 'wt']);
-    }
-
-    private function isReadable()
-    {
-        return in_array($this->mode, ['r', 'rb', 'rt']);
-    }
-
     // @codingStandardsIgnoreStart
     /**
      * Callback handler for when we try to read a certain number of bytes.
@@ -195,7 +207,7 @@ class StreamWrapper
     public function stream_read($count)
     {
         // @codingStandardsIgnoreEnd
-        return $this->getStream()->read($count);
+        return $this->stream->read($count);
     }
 
     // @codingStandardsIgnoreStart
@@ -209,7 +221,7 @@ class StreamWrapper
     public function stream_write($data)
     {
         // @codingStandardsIgnoreEnd
-        return $this->getStream()->write($data);
+        return $this->stream->write($data);
     }
 
     // @codingStandardsIgnoreStart
@@ -221,31 +233,13 @@ class StreamWrapper
     public function stream_stat()
     {
         // @codingStandardsIgnoreEnd
-        $size = $this->getStream()->getSize();
-        if (!$size) {
-            foreach ($this->getStream()->getMetadata('wrapper_data') as $value) {
-                if (substr($value, 0, 15) == "Content-Length:") {
-                    $size = (int) substr($value, 16);
-                    break;
-                }
-            }
-        }
-
-        return [
-            'dev'     => 0,
-            'ino'     => 0,
-            'mode'    => $this->isWriteable() ? 33188 : 33060, // equivalent to 10644 and 10444 in octal
-            'nlink'   => 0,
-            'uid'     => 0,
-            'gid'     => 0,
-            'rdev'    => 0,
-            'size'    => $size,
-            'atime'   => 0,
-            'mtime'   => 0,
-            'ctime'   => 0,
-            'blksize' => 0,
-            'blocks'  => 0
-        ];
+        $mode = $this->stream->isWritable()
+            ? self::FILE_WRITABLE_MODE
+            : self::FILE_READABLE_MODE;
+        return $this->makeStatArray([
+            'mode'    => $mode,
+            'size'    => $this->stream->getSize()
+        ]);
     }
 
     // @codingStandardsIgnoreStart
@@ -257,7 +251,7 @@ class StreamWrapper
     public function stream_eof()
     {
         // @codingStandardsIgnoreEnd
-        return $this->getStream()->eof();
+        return $this->stream->eof();
     }
 
     // @codingStandardsIgnoreStart
@@ -268,7 +262,7 @@ class StreamWrapper
     {
         // @codingStandardsIgnoreEnd
         if (isset($this->stream)) {
-            $this->getStream()->close();
+            $this->stream->close();
         }
     }
 
@@ -284,7 +278,6 @@ class StreamWrapper
     public function stream_seek($offset, $whence = SEEK_SET)
     {
         // @codingStandardsIgnoreEnd
-        // Currently cannot seek (using BufferStreams)
         if ($this->stream->isSeekable()) {
             $this->stream->seek($offset, $whence);
             return true;
@@ -301,7 +294,7 @@ class StreamWrapper
     public function stream_tell()
     {
         // @codingStandardsIgnoreEnd
-        return $this->getStream()->tell();
+        return $this->stream->tell();
     }
 
     // @codingStandardsIgnoreStart
@@ -380,7 +373,7 @@ class StreamWrapper
         $this->file = $this->makeDirectory($this->file);
 
         try {
-            $this->bucket->upload("", [
+            $this->bucket->upload('', [
                 'name' => $this->file
             ]);
         } catch (ServiceException $e) {
@@ -389,11 +382,16 @@ class StreamWrapper
         return true;
     }
 
+    /**
+     * Parse the URL and set protocol, filename and bucket.
+     * @param  string $path URL to open
+     * @return StorageClient
+     */
     private function openPath($path)
     {
         $url = parse_url($path);
         $this->protocol = $url['scheme'];
-        $this->file = substr($url['path'], 1);
+        $this->file = ltrim($url['path'], '/');
         $client = self::getClient($this->protocol);
         $this->bucket = $client->bucket($url['host']);
         return $client;
@@ -516,22 +514,12 @@ class StreamWrapper
         }
 
         // equivalent to 40777 and 40444 in octal
-        $mode = $this->isBucketWritable($this->file) ? 16895 : 16676;
-        return [
-            'dev'     => 0,
-            'ino'     => 0,
-            'mode'    => $mode,
-            'nlink'   => 0,
-            'uid'     => 0,
-            'gid'     => 0,
-            'rdev'    => 0,
-            'size'    => 0,
-            'atime'   => 0,
-            'mtime'   => 0,
-            'ctime'   => 0,
-            'blksize' => 0,
-            'blocks'  => 0
-        ];
+        $mode = $this->isBucketWritable($this->file)
+            ? self::DIRECTORY_WRITABLE_MODE
+            : self::DIRECTORY_READABLE_MODE;
+        return $this->makeStatArray([
+            'mode'    => $mode
+        ]);
     }
 
     private function urlStatFile()
@@ -545,26 +533,19 @@ class StreamWrapper
         }
 
         // equivalent to 100666 and 100444 in octal
-        $mode = $this->isBucketWritable() ? 33206 : 33060;
+        $mode = $this->isBucketWritable()
+            ? self::FILE_WRITABLE_MODE
+            : self::FILE_READABLE_MODE;
         $size = (int) $info['size'];
         $updated = strtotime($info['updated']);
         $created = strtotime($info['timeCreated']);
 
-        return [
-            'dev'     => 0,
-            'ino'     => 0,
-            'mode'    => $mode,
-            'nlink'   => 0,
-            'uid'     => 0,
-            'gid'     => 0,
-            'rdev'    => 0,
-            'size'    => $size,
-            'atime'   => 0,
-            'mtime'   => $updated,
-            'ctime'   => $created,
-            'blksize' => 0,
-            'blocks'  => 0
-        ];
+        return $this->makeStatArray([
+            'mode'  => $mode,
+            'size'  => $size,
+            'mtime' => $updated,
+            'ctime' => $created
+        ]);
     }
 
     /**
@@ -598,5 +579,13 @@ class StreamWrapper
     private function isDirectory($path)
     {
         return substr($path, -1) == '/';
+    }
+
+    private function makeStatArray($stats)
+    {
+        return array_merge(
+            array_fill_keys(self::STAT_KEYS, 0),
+            $stats
+        );
     }
 }

--- a/src/Storage/StreamWrapper.php
+++ b/src/Storage/StreamWrapper.php
@@ -514,7 +514,7 @@ class StreamWrapper
         }
 
         // equivalent to 40777 and 40444 in octal
-        $mode = $this->isBucketWritable($this->file)
+        $mode = $this->bucket->isWritable()
             ? self::DIRECTORY_WRITABLE_MODE
             : self::DIRECTORY_READABLE_MODE;
         return $this->makeStatArray([
@@ -533,7 +533,7 @@ class StreamWrapper
         }
 
         // equivalent to 100666 and 100444 in octal
-        $mode = $this->isBucketWritable()
+        $mode = $this->bucket->isWritable()
             ? self::FILE_WRITABLE_MODE
             : self::FILE_READABLE_MODE;
         $size = (int) $info['size'];
@@ -546,34 +546,6 @@ class StreamWrapper
             'mtime' => $updated,
             'ctime' => $created
         ]);
-    }
-
-    /**
-     * Returns whether the bucket with the given file prefix is writable.
-     * Tries to create a temporary file as a resumable upload which will
-     * not be completed (and cleaned up by GCS).
-     *
-     * @param  string  $prefix Optional folder within the bucket.
-     * @return boolean
-     */
-    private function isBucketWritable($prefix = null)
-    {
-        $name = '__tempfile';
-        if ($prefix) {
-            $name = "$prefix/$name";
-        }
-        $uploader = $this->bucket->getResumableUploader(
-          Psr7\stream_for(''),
-          ['name' => $name]
-        );
-        try {
-            $uploader->getResumeUri();
-        } catch (ServiceException $e) {
-            throw $e;
-            return false;
-        }
-
-        return true;
     }
 
     private function isDirectory($path)

--- a/src/Storage/WriteStream.php
+++ b/src/Storage/WriteStream.php
@@ -1,0 +1,103 @@
+<?php
+/**
+ * Copyright 2015 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Storage;
+
+use Google\Cloud\Upload\AbstractUploader;
+use GuzzleHttp\Psr7\StreamDecoratorTrait;
+use GuzzleHttp\Psr7\BufferStream;
+use Psr\Http\Message\StreamInterface;
+
+/**
+ * A Stream implementation that uploads in chunks to a provided uploader when
+ * we reach a certain chunkSize. Upon `close`, we will upload the remaining chunk.
+ */
+class WriteStream implements StreamInterface
+{
+    use StreamDecoratorTrait;
+
+    private $uploader;
+    private $stream;
+    private $chunkSize = 262144;
+
+    /**
+     * Create a new WriteStream instance
+     *
+     * @param AbstractUploader $uploader The uploader to use.
+     * @param array $options [optional] {
+     *      Configuration options.
+     *
+     *      @type int $chunkSize The size of the buffer above which we attempt to
+     *            upload data
+     * }
+     */
+    public function __construct($uploader = null, $options = [])
+    {
+        if ($uploader) {
+            $this->setUploader($uploader);
+        }
+        if (array_key_exists('chunkSize', $options)) {
+            $this->chunkSize = $options['chunkSize'];
+        }
+        $this->stream = new BufferStream($this->chunkSize);
+    }
+
+    /**
+     * Close the stream. Uploads any remaining data.
+     */
+    public function close()
+    {
+        if ($this->uploader) {
+            $this->uploader->upload();
+            $this->uploader = null;
+        }
+    }
+
+    /**
+     * Write to the stream. If we pass the chunkable size, upload the available chunk.
+     *
+     * @param  string|StreamInterface $data Data to write
+     * @return int The number of bytes written
+     */
+    public function write($data)
+    {
+        if (!$this->stream->write($data)) {
+            $this->uploader->upload($this->getChunkedWriteSize());
+        }
+        return strlen($data);
+    }
+
+    /**
+     * Set the uploader for this class. You may need to set this after initialization
+     * if the uploader depends on this stream.
+     *
+     * @param AbstractUploader $uploader The new uploader to use.
+     */
+    public function setUploader($uploader)
+    {
+        $this->uploader = $uploader;
+
+        // Ensure we have a resume uri here because we need to create the streaming
+        // upload before we have data (size of 0).
+        $this->uploader->getResumeUri();
+    }
+
+    private function getChunkedWriteSize()
+    {
+        return floor($this->getSize() / $this->chunkSize) * $this->chunkSize;
+    }
+}

--- a/src/Storage/WriteStream.php
+++ b/src/Storage/WriteStream.php
@@ -98,6 +98,6 @@ class WriteStream implements StreamInterface
 
     private function getChunkedWriteSize()
     {
-        return floor($this->getSize() / $this->chunkSize) * $this->chunkSize;
+        return (int) floor($this->getSize() / $this->chunkSize) * $this->chunkSize;
     }
 }

--- a/tests/unit/Storage/ReadStreamTest.php
+++ b/tests/unit/Storage/ReadStreamTest.php
@@ -1,0 +1,68 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Storage;
+
+use Google\Cloud\Storage\ReadStream;
+use Google\Cloud\Upload\StreamableUploader;
+use Prophecy\Argument;
+
+/**
+ * @group storage
+ */
+class ReadStreamTest extends \PHPUnit_Framework_TestCase
+{
+    const TEST_HEADERS = [
+        "Foo: bar",
+        "User-Agent: php",
+        "Content-Length: 1234",
+        "Asdf: qwer",
+    ];
+
+    public function testReadsFromHeadersWhenGetSizeIsNull()
+    {
+        $httpStream = $this->prophesize('Psr\Http\Message\StreamInterface');
+        $httpStream->getSize()->willReturn(null);
+        $httpStream->getMetadata('wrapper_data')->willReturn(self::TEST_HEADERS);
+
+        $stream = new ReadStream($httpStream->reveal());
+
+        $this->assertEquals(1234, $stream->getSize());
+    }
+
+    public function testReadsFromHeadersWhenGetSizeIsZero()
+    {
+        $httpStream = $this->prophesize('Psr\Http\Message\StreamInterface');
+        $httpStream->getSize()->willReturn(0);
+        $httpStream->getMetadata('wrapper_data')->willReturn(self::TEST_HEADERS);
+
+        $stream = new ReadStream($httpStream->reveal());
+
+        $this->assertEquals(1234, $stream->getSize());
+    }
+
+    public function testNoContentLengthHeader()
+    {
+        $httpStream = $this->prophesize('Psr\Http\Message\StreamInterface');
+        $httpStream->getSize()->willReturn(null);
+        $httpStream->getMetadata('wrapper_data')->willReturn(array());
+
+        $stream = new ReadStream($httpStream->reveal());
+
+        $this->assertEquals(0, $stream->getSize());
+    }
+}

--- a/tests/unit/Storage/WriteStreamTest.php
+++ b/tests/unit/Storage/WriteStreamTest.php
@@ -1,0 +1,56 @@
+<?php
+/**
+ * Copyright 2017 Google Inc. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+namespace Google\Cloud\Tests\Storage;
+
+use Google\Cloud\Storage\WriteStream;
+use Google\Cloud\Upload\StreamableUploader;
+use Prophecy\Argument;
+
+
+/**
+ * @group storage
+ */
+class WriteStreamTest extends \PHPUnit_Framework_TestCase
+{
+    public function testUploadsWhenWriteOverflowsBuffer()
+    {
+        $uploader = $this->prophesize(StreamableUploader::class);
+        $uploader->getResumeUri()->willReturn('https://some-resume-uri/');
+        $stream = new WriteStream($uploader->reveal(), ['chunkSize' => 10]);
+
+        // We should see 2 calls to upload with size of 10.
+        $upload = $uploader->upload(10)->will(function($args) use ($stream) {
+            if (count($args) > 0) {
+                $size = $args[0];
+                $stream->read(10);
+            }
+            return array();
+        });
+
+        // We should see a single call to finish the upload.
+        $uploader->upload()->shouldBeCalledTimes(1);
+
+        $stream->write('1234567');
+        $upload->shouldHaveBeenCalledTimes(0);
+        $stream->write('8901234');
+        $upload->shouldHaveBeenCalledTimes(1);
+        $stream->write('5678901');
+        $upload->shouldHaveBeenCalledTimes(2);
+        $stream->close();
+    }
+}


### PR DESCRIPTION
Implement ReadStream to wrap lazy downloaded stream to provide the size of the stream

Instead of `StreamingUploader` acting like a `StreamInterface`, we wrap it with a `WriteStream` class that tells the uploader when to send a chunk. Now, in the stream wrapper, `$this->stream` is always a `StreamInterface` instance.